### PR TITLE
fix(DataScroller): remove font size on sticky element

### DIFF
--- a/src/DataScroller.tsx
+++ b/src/DataScroller.tsx
@@ -210,7 +210,6 @@ const DataScroller = (props: DataTableProps) => {
           className="sticky"
           style={{
             display: 'flex',
-            fontSize: '20px',
             top: 0,
           }}
         >


### PR DESCRIPTION
Found a rogue font size on the sticky element, it's messing with our applications internal font sizes since it has precedence. Assuming we don't need it!