### PR TITLE
feat(getRowKey): create a method that determines the key of each row

### DIFF
--- a/src/DataScroller.tsx
+++ b/src/DataScroller.tsx
@@ -16,7 +16,7 @@ import useTotalVisibleRows from './hooks/useTotalVisibleRows';
 import Stickyfill from 'stickyfilljs';
 
 /* Types */
-import { DataTableProps } from './types';
+import { DataTableProps, GetRowKey } from './types';
 
 /* Styles */
 import './styles.css';
@@ -238,6 +238,7 @@ const DataScroller = (props: DataTableProps) => {
                 rowHeight={props.rowHeight}
                 rowRenderer={props.rowRenderer}
                 rowCount={props.rowCount}
+                getRowKey={props.getRowKey}
               />
             </div>
           </div>
@@ -264,6 +265,7 @@ const DataScroller = (props: DataTableProps) => {
                 rowHeight={props.rowHeight}
                 rowRenderer={props.rowRenderer}
                 rowCount={props.rowCount}
+                getRowKey={props.getRowKey}
               />
             </div>
           </div>
@@ -273,6 +275,9 @@ const DataScroller = (props: DataTableProps) => {
   );
 };
 
+const defaultGetRowKey: GetRowKey = ({ renderIndex, topRowIndex }) =>
+  renderIndex + topRowIndex;
+
 DataScroller.defaultProps = {
   frozenColumns: [],
   groupHeaderHeight: 0,
@@ -281,6 +286,7 @@ DataScroller.defaultProps = {
   onRowsRendered: ({}) => undefined,
   rowRenderer: defaultRowRenderer,
   scrollToIndex: null,
+  getRowKey: defaultGetRowKey,
 };
 
 export default React.memo(DataScroller);

--- a/src/components/Rows/Rows.tsx
+++ b/src/components/Rows/Rows.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RowGetter, RowProps } from '../../types';
+import { RowGetter, RowProps, GetRowKey } from '../../types';
 import { Props as ColumnProps } from '../Column';
 
 export type Props = {
@@ -10,6 +10,7 @@ export type Props = {
   totalVisibleRows: number;
   rowGetter: RowGetter;
   rowCount: number;
+  getRowKey: GetRowKey;
 };
 
 function Rows({
@@ -20,20 +21,24 @@ function Rows({
   totalVisibleRows,
   rowGetter,
   rowCount,
+  getRowKey,
 }: Props) {
   const RowRenderer = rowRenderer;
 
   return (
     <div>
-      {Array.apply(null, new Array(totalVisibleRows)).map((_, index) => {
-        const rowIndex = topRowIndex + index;
+      {Array.apply(null, new Array(totalVisibleRows)).map((_, renderIndex) => {
+        const rowIndex = topRowIndex + renderIndex;
         const row = rowGetter({ index: rowIndex });
         if (rowIndex > rowCount - 1) {
           return null;
         }
 
         return (
-          <div style={{ height: rowHeight, display: 'flex' }} key={index}>
+          <div
+            style={{ height: rowHeight, display: 'flex' }}
+            key={getRowKey({ renderIndex, topRowIndex })}
+          >
             <RowRenderer rowIndex={rowIndex}>
               {columns.map((column, columnIndex) => (
                 <div key={columnIndex} style={{ width: column.width }}>

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,4 +17,5 @@ export {
   OnRowsRenderedArgs,
   RowGetterArgs,
   RowProps,
+  GetRowKey,
 } from './types';

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,7 +42,13 @@ export type DataTableProps = {
   rowRenderer: React.FC<RowProps>;
   scrollToIndex: number | null;
   width: number;
+  getRowKey: GetRowKey;
 };
+
+export type GetRowKey = (args: {
+  renderIndex: number;
+  topRowIndex: number;
+}) => number;
 
 export type DataTableState = {
   tableScrollHeight: number;

--- a/stories/index.stories.tsx
+++ b/stories/index.stories.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { Column, ColumnProps } from '../src/';
 import Group from '../src/components/Group';
 import Row from '../src/components/Row';
-import { RowProps } from '../src/types';
+import { RowProps, GetRowKey } from '../src/types';
 
 import { storiesOf } from '@storybook/react';
 import DataScroller, {
@@ -127,6 +127,37 @@ storiesOf('react-data-scroller', module).add('default', () => (
     frozenColumns={frozenColumns.map((column, index) => (
       <Column key={index} {...column} />
     ))}
+  />
+));
+
+const customGetRowKey: GetRowKey = ({ renderIndex }) => renderIndex;
+
+storiesOf('react-data-scroller', module).add('custom row key', () => (
+  <DataScroller
+    rowCount={rowCount}
+    rowGetter={rowGetter}
+    rowHeight={50}
+    height={500}
+    headerHeight={100}
+    width={500}
+    initialTopRowIndex={50}
+    groupHeaderHeight={30}
+    columns={[
+      <Group key="groupa" headerRenderer={GroupHeaderA}>
+        {columns.map((column, index) => (
+          <Column key={index} {...column} />
+        ))}
+      </Group>,
+      <Group key="groupb" headerRenderer={GroupHeaderB}>
+        {columns.map((column, index) => (
+          <Column key={index} {...column} />
+        ))}
+      </Group>,
+    ]}
+    frozenColumns={frozenColumns.map((column, index) => (
+      <Column key={index} {...column} />
+    ))}
+    getRowKey={customGetRowKey}
   />
 ));
 


### PR DESCRIPTION
This can be used for optimizations in cases where your data is read only
to prevent rows from unmounting and mounting. This used to be the default
behavior but can lead to broken experiences when there are stateful child
components in the row.